### PR TITLE
Add DB_NAME env var

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -32,7 +32,8 @@ Environment flags:
 - OSCAR_PORT: port to bind to (default: 5190)
 - OSCAR_BOS_HOST: hostname of Basic OSCAR Service that provides core client features (default: 0.0.0.0)
 - OSCAR_BOS_PORT: port of Basic OSCAR Service (default: 5190)
-- DB_URL: URL of Postgres database to use
+- DB_URL: URL of PostgreSQL host
+- DB_NAME: Name of the database to use
 - DB_USER: Username of the db user
 - DB_PASSWORD: Password of the db user
 

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -21,6 +21,7 @@ var (
 	DB_URL      = ""
 	DB_USER     = ""
 	DB_PASSWORD = ""
+	DB_NAME     = ""
 )
 
 func init() {
@@ -36,6 +37,10 @@ func init() {
 		DB_PASSWORD = strings.TrimSpace(dbPassword)
 	}
 
+	if dbName, ok := os.LookupEnv("DB_NAME"); ok {
+		DB_NAME = strings.TrimSpace(dbName)
+	}
+
 	if len(os.Args) != 2 {
 		log.Fatalf("Usage: %s <init|up|down|status|mark_applied>", os.Args[0])
 	}
@@ -48,7 +53,7 @@ func main() {
 		pgdriver.WithTLSConfig(&tls.Config{InsecureSkipVerify: true}),
 		pgdriver.WithUser(DB_USER),
 		pgdriver.WithPassword(DB_PASSWORD),
-		pgdriver.WithDatabase("postgres"),
+		pgdriver.WithDatabase(DB_NAME),
 		pgdriver.WithInsecure(true),
 		pgdriver.WithTimeout(5*time.Second),
 		pgdriver.WithDialTimeout(5*time.Second),

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -27,18 +27,26 @@ var (
 func init() {
 	if dbUrl, ok := os.LookupEnv("DB_URL"); ok {
 		DB_URL = strings.TrimSpace(dbUrl)
+	} else {
+		log.Fatalf("Missing DB_URL env variable")
 	}
 
 	if dbUser, ok := os.LookupEnv("DB_USER"); ok {
 		DB_USER = strings.TrimSpace(dbUser)
+	} else {
+		log.Fatalf("Missing DB_USER env variable")
 	}
 
 	if dbPassword, ok := os.LookupEnv("DB_PASSWORD"); ok {
 		DB_PASSWORD = strings.TrimSpace(dbPassword)
+	} else {
+		log.Fatalf("Missing DB_PASSWORD env variable")
 	}
 
 	if dbName, ok := os.LookupEnv("DB_NAME"); ok {
 		DB_NAME = strings.TrimSpace(dbName)
+	} else {
+		log.Fatalf("Missing DB_NAME env variable")
 	}
 
 	if len(os.Args) != 2 {

--- a/env/example.dev.env
+++ b/env/example.dev.env
@@ -3,4 +3,5 @@ export POSTGRES_PASSWORD=password
 export DB_URL="$(hostname):5432"
 export DB_USER=${POSTGRES_USER}
 export DB_PASSWORD=${POSTGRES_PASSWORD}
+export DB_NAME=oscar
 export OSCAR_BOS_HOST=$(osascript -e "IPv4 address of (system info)")

--- a/env/example.dev.env
+++ b/env/example.dev.env
@@ -4,4 +4,4 @@ export DB_URL="$(hostname):5432"
 export DB_USER=${POSTGRES_USER}
 export DB_PASSWORD=${POSTGRES_PASSWORD}
 export DB_NAME=oscar
-export OSCAR_BOS_HOST=$(osascript -e "IPv4 address of (system info)")
+export OSCAR_BOS_HOST="$(osascript -e "IPv4 address of (system info)")"

--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ var (
 	DB_URL            = ""
 	DB_USER           = ""
 	DB_PASSWORD       = ""
+	DB_NAME           = ""
 )
 
 func init() {
@@ -75,6 +76,10 @@ func init() {
 		DB_PASSWORD = strings.TrimSpace(dbPassword)
 	}
 
+	if dbName, ok := os.LookupEnv("DB_NAME"); ok {
+		DB_NAME = strings.TrimSpace(dbName)
+	}
+
 	flag.Parse()
 
 	OSCAR_HOST = oscarHost
@@ -96,6 +101,10 @@ func init() {
 	if DB_PASSWORD == "" {
 		log.Fatalln("DB password not specified")
 	}
+
+	if DB_NAME == "" {
+		log.Fatalln("DB name not specified")
+	}
 }
 
 func main() {
@@ -105,7 +114,7 @@ func main() {
 		pgdriver.WithTLSConfig(&tls.Config{InsecureSkipVerify: true}),
 		pgdriver.WithUser(DB_USER),
 		pgdriver.WithPassword(DB_PASSWORD),
-		pgdriver.WithDatabase("postgres"),
+		pgdriver.WithDatabase(DB_NAME),
 		pgdriver.WithInsecure(true),
 		pgdriver.WithTimeout(5*time.Second),
 		pgdriver.WithDialTimeout(5*time.Second),

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
-source env/dev.env
-npm install
-npm run dev
+. dev.env
+./aim-oscar


### PR DESCRIPTION
Picking up https://github.com/amigan/aim-oscar-server/commit/64f7831fe16c8341f1de414b397995477d087b05, which pointed out I still had a hardcoded database name.

Added some error handling for these vars as well.