### PR TITLE
Update example.config.yml

### DIFF
--- a/env/example.config.yml
+++ b/env/example.config.yml
@@ -3,7 +3,7 @@ app:
 
 oscar:
   addr: 0.0.0.0:5190
-  bos_addr: 10.0.1.29:5190
+  bos: 10.0.1.29:5190
 
 db:
   name: postgres


### PR DESCRIPTION
Using `bos_addr` causes init to fail. Naming the field `bos` fixes init.